### PR TITLE
Support ACI

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -61,9 +61,9 @@ class Client {
      * @return string
      */
     protected function getAccessToken() {
-        // Get MSI endpoint & token from environment (App Service) or use hardcoded values in case of VM
+        // Get MSI endpoint & token from environment (App Service) or use hardcoded values in case of VM/ACI
         $endpoint = $this->env('IDENTITY_ENDPOINT', 'http://169.254.169.254/metadata/identity/oauth2/token');
-        $idHeaderValue = $this->env('IDENTITY_HEADER', 'true');
+        $idHeaderValue =  !empty($this->env('IDENTITY_ENDPOINT')) ? $this->env('IDENTITY_HEADER') : 'true';
         $idHeaderName = !empty($this->env('IDENTITY_ENDPOINT')) ? 'X-IDENTITY-HEADER' : 'Metadata';
         $resource = 'https://vault.azure.net';
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -64,7 +64,7 @@ class Client {
         // Get MSI endpoint & token from environment (App Service) or use hardcoded values in case of VM
         $endpoint = $this->env('IDENTITY_ENDPOINT', 'http://169.254.169.254/metadata/identity/oauth2/token');
         $idHeaderValue = $this->env('IDENTITY_HEADER', 'true');
-        $idHeaderName = !empty($this->env('IDENTITY_HEADER')) ? 'X-IDENTITY-HEADER' : 'Metadata';
+        $idHeaderName = !empty($this->env('IDENTITY_ENDPOINT')) ? 'X-IDENTITY-HEADER' : 'Metadata';
         $resource = 'https://vault.azure.net';
 
         $endpoint = Url::fromString($endpoint)->withQueryParameter('resource', $resource);


### PR DESCRIPTION
When running inside an Azure Container Instance, `IDENTITY_ENDPOINT` is NOT present, but `IDENTITY_HEADER` header is.

Strangely, Azure still expects `Metadata=true`. I can't find any documentation supporting this, but it was found using trial and error.

This PR adds functionality to decide whether to use `X-IDENTITY-HEADER` or `Metadata`, based on the presence of the `IDENTITY_ENDPOINT` variable. This should work for both regular cases, VM's and ACI's.