### PR TITLE
Add client credentials support + fix managed identity authentication

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -7,7 +7,7 @@ use Spatie\Url\Url;
 
 class Client
 {
-    public const OAUTH_API_VERSION = '2021-12-13';
+    public const OAUTH_API_VERSION = '2019-08-01';
 
     public const VAULT_API_VERSION = '7.0';
 


### PR DESCRIPTION
This proposal add a way to obtain a bearer from azure with the client_credentials flow (with a client_id and secret) in addition of the managed identity authentication.

It fixed also the authentication with managed identities, by adding the metadata header (to fix SSRF issues on azure side), it adds support of user-assigned managed identities in addition of system-assigned one (by adding the client_id) 